### PR TITLE
Fix index.js path bug introduced by multi-embed variants

### DIFF
--- a/src/www/embed.hbs
+++ b/src/www/embed.hbs
@@ -145,7 +145,7 @@ var riveted=function(){function e(e){e=e||{},g=parseInt(e.reportInterval,10)||5,
 {{/if}}
 
 {{#if rootRef}}
-<script src="/{{{jsResolvedFileName}}}"></script>
+<script src="/{{{assetPath 'index.js'}}}"></script>
 {{else}}
 <script src="{{{jsResolvedFileName}}}"></script>
 {{/if}}


### PR DESCRIPTION
This fixes the index.js path bug introduced by https://github.com/lucified/lucify-component-builder/pull/4.

The bug was originally missed as it only affects dist builds. The bugfix has been tested with all the four test-projects. 
