### PR TITLE
Multi embed bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "minimist": "^1.2.0",
     "mkpath": "^0.1.0",
     "query-string": "^2.4.1",
+    "replaceall": "^0.1.6",
     "through2": "^2.0.0"
   },
   "browserify": {

--- a/src/js/prepare-build-tasks.js
+++ b/src/js/prepare-build-tasks.js
@@ -118,13 +118,13 @@ function bundleComponents(opts, context) {
 
 
 function getJsFileName(edef) {
-    var ret = edef.path === '' ? 'index.js' : 'index-' + replaceall(edef.path, '/', '-') + '.js';
+    var ret = edef.path === '' ? 'index.js' : 'index' + replaceall('/', '-', edef.path) + '.js';
     return ret;
 }
 
 
 function getTempFileName(edef) {
-    var ret = edef.path === '' ? 'component.jsx' : 'component-' + replaceall(edef.path, '/', '-') + '.jsx';
+    var ret = edef.path === '' ? 'component.jsx' : 'component' + replaceall('/', '-', edef.path) + '.jsx';
     return ret;
 }
 

--- a/src/js/prepare-build-tasks.js
+++ b/src/js/prepare-build-tasks.js
@@ -10,6 +10,7 @@ var del = require('del');
 var parseArgs = require('minimist');
 var deepcopy = require('deepcopy');
 var mergeStream = require('merge-stream');
+var replaceall = require("replaceall");
 
 var buildTools = require('lucify-build-tools');
 var embedCode = require('lucify-commons/src/js/embed-code.js');
@@ -117,13 +118,13 @@ function bundleComponents(opts, context) {
 
 
 function getJsFileName(edef) {
-    var ret = edef.path === '' ? 'index.js' : 'index' + edef.path.replace('/', '-') + '.js';
+    var ret = edef.path === '' ? 'index.js' : 'index-' + replaceall(edef.path, '/', '-') + '.js';
     return ret;
 }
 
 
 function getTempFileName(edef) {
-    var ret = edef.path === '' ? 'component.jsx' : 'component' + edef.path.replace('/', '-') + '.jsx';
+    var ret = edef.path === '' ? 'component.jsx' : 'component-' + replaceall(edef.path, '/', '-') + '.jsx';
     return ret;
 }
 

--- a/test-projects/multi-embed-test-project/gulpfile.babel.js
+++ b/test-projects/multi-embed-test-project/gulpfile.babel.js
@@ -8,7 +8,7 @@ var embedDefs = [
   },
   {
     componentPath: 'src/js/components/hello-world-two.jsx',
-    path: '/hello-world-two'
+    path: '/subpath/hello-world-two'
   }
 ];
 


### PR DESCRIPTION
Fixes a bug causing multi-embed packages to build incorrectly when the paths defined in embedDefs have multiple forward slashes.

Tested with `multi-embed-test-project` and `lucify-taxes`.
