### PR TITLE
Add support for less

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "handlebars-loader": "^1.1.4",
     "html-webpack-plugin": "^2.8.2",
     "json-loader": "^0.5.4",
+    "less": "^2.6.1",
+    "less-loader": "^2.2.2",
     "libsodium-wrappers": "^0.2.12",
     "lodash": "^4.4.0",
     "lucify-commons": "~0.2.3",

--- a/src/js/bundle-webpack.js
+++ b/src/js/bundle-webpack.js
@@ -263,6 +263,15 @@ function getLoaders(babelPaths) {
       require.resolve('sass-loader')
     ]
   }, {
+    test: /\.less$/,
+    loaders: [
+      require.resolve('style-loader'),
+      require.resolve('css-loader') + '?modules&importLoaders=2&localIdentName=[name]__[local]___[hash:base64:5]',
+      require.resolve('postcss-loader'),
+      require.resolve('less-loader')
+    ]
+  },
+  {
     test: /\.(jpeg|jpg|gif|png)$/,
     loaders: [require.resolve('file-loader') + '?name=[name]-[hash:12].[ext]']
   }, {


### PR DESCRIPTION
Unfortunately to use Semantic UI properly, we need to be able include `.less` files as well. Apparently they are working on a proper SASS port, but there are roadblocks (see the bottom of the README at https://github.com/Semantic-Org/Semantic-UI).
