### PR TITLE
Change build.js to index-[hash].js to support cache busting

### DIFF
--- a/src/js/bundle-webpack.js
+++ b/src/js/bundle-webpack.js
@@ -74,6 +74,10 @@ function bundle(
     watch: watch
   };
 
+  if (!config.output.filename) {
+    config.output.filename = 'index-[hash].js';
+  }
+
   if(process.env.NODE_ENV === envs.STAGING || process.env.NODE_ENV === envs.PRODUCTION) {
     config.plugins = config.plugins.concat([
       new webpack.optimize.UglifyJsPlugin(),


### PR DESCRIPTION
Fixes https://github.com/lucified/lucify-component-builder/issues/26
