### PR TITLE
Custom templates

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,7 +7,8 @@ TODO: this is work-in-progress
 
 ### General options
 
-- `assetContext`: HTTP path for the entry point `ìndex.html`, including trailing slash, not including `baseUrl` defaults to `''`.
+- `entryPoint`: Absolute path to entry point for Javascript bundle. When this option is defined, the file at given path will be directly used as entry point for the main javascript bundle.
+- `assetContext`: HTTP path for the entry point `ìndex.html`, including trailing slash, not including `baseUrl`. Defaults to `''`.
 - `flow`: Flow id of flow in which to send notifications
 - `maxAge`: The maxAge for HTTP cache headers for assets with rev urls
 - `bucket`: The s3 bucket in which to deploy
@@ -17,24 +18,23 @@ TODO: this is work-in-progress
 - `project`: GitHub project name
 - `org`: GitHub organization name,
 - `embedCodes`: Set to `true` to generate `embed-codes.html` along boostrapping `index.html`
+- `embedCodesHtmlTemplate`: Absolute path to page template for `embed-codes.html` page. Defaults to (this)[https://github.com/lucified/lucify-component-builder/blob/master/src/www/embed-codes.hbs] template.
+- `reactRouter`: Set to `true` to use react-router -bootstrapping code as entry point, instead of bootstrapping as React component. Defaults to `false`. This option only applies when `entryPoint` is not defined.
 
-### Options for bootstrapping `index.html`
+### Options for bootstrapping index.html
 
-- `iframeResize`: Set to `true` to bundle IFrame resizing code into bootstrapping index.html. Defaults to `true`
-- `reactRouter`: Set to `true` to bootstrap with react-router -based project, instead of bootstrapping as React component. Defaults to `false`.
-- `googleAds`: Set to `true` to enable script src snippet in `index.html` for Google ads. Defaults to `true`. TODO: should be Google Ads Id instead of boolean.
-- `googleAnalytics`: Set to `true` to enable script src snippet in `index.html` for Google Analytics. Defaults to `true`. TODO: should be Google Analytics Id instead of boolean.
-- `riveted`: Set to `true` to enable script src snippet in `index.html` for Riveted.js. Defaults to `true`.
-
-### Options for single-page projects
-
-`pageDef`: object containing page metadata for entry point. The following attributes are recognized:
-- `title`: Page title
-- `description`: Description metadata for social sharing, etc,
-- `ogType`: Open graph type
-- `twitterImage`: Filename for twitter card image
-- `openGraphImage`: Filename for open graph (Facebook) image
-- `schemaImage`: 'Filename for schema image
+- `pageDef`: object containing page metadata for entry point. The following attributes are recognized:
+    + `title`: Page title
+    + `description`: Description metadata for social sharing, etc,
+    + `ogType`: Open graph type
+    + `twitterImage`: Filename for twitter card image
+    + `openGraphImage`: Filename for open graph (Facebook) image
+    + `schemaImage`: 'Filename for schema image
+    + `googleAds`: Set to `true` to enable script src snippet in `index.html` for Google ads. Defaults to `true`. TODO: should be Google Ads Id instead of boolean.
+    + `googleAnalytics`: Set to `true` to enable script src snippet in `index.html` for Google Analytics. Defaults to `true`. TODO: should be Google Analytics Id instead of boolean.
+    + `riveted`: Set to `true` to enable script src snippet in `index.html` for Riveted.js. Defaults to `true`.
+    + `iframeResize`: Set to `true` to bundle IFrame resizing code into bootstrapping index.html. Defaults to `true`
+    + `indexHtmlTemplate`: Absolute path to handlebars template for `index.html`. Defaults to (this)[https://github.com/lucified/lucify-component-builder/blob/master/src/www/embed.hbs] template.
 
 ### Options for multi-page React-router projects
 

--- a/src/js/bundle-webpack.js
+++ b/src/js/bundle-webpack.js
@@ -123,7 +123,7 @@ function htmlWebpackPluginsFromPageDefs(pageDefs, watch) {
     }
 
     var config = {
-      template: require.resolve('../www/embed.hbs'),
+      template: item.indexHtmlTemplate || require.resolve('../www/embed.hbs'),
       inject: false,
       filename: path.join(itemPath, 'index.html'),
 

--- a/src/js/bundle-webpack.js
+++ b/src/js/bundle-webpack.js
@@ -7,7 +7,7 @@ const gutil         = require('gulp-util'),
   parseArgs         = require('minimist'),
   envs              = require('./envs.js'),
   autoprefixer      = require('autoprefixer'),
-  postcssReporter   = require('postcss-reporter');
+  postcssReporter   = require('postcss-reporter'),
   getport           = require('getport');
 
 var options = parseArgs(process.argv, {

--- a/src/js/embed-code-utils.js
+++ b/src/js/embed-code-utils.js
@@ -16,24 +16,24 @@ function embedCodes(context, opts, baseUrl, assetContext, cb) {
 
   if (Array.isArray(opts.embedDefs)) {
     return mergeStream(opts.embedDefs.map(function(def) {
-      return embedCodesPage(context, baseUrl, assetContext, def.path, cb);
+      return embedCodesPage(context, baseUrl, assetContext, def.path, opts.embedCodesHtmlTemplate, cb);
     }));
   }
-  return embedCodesPage(context, baseUrl, assetContext, '', cb);
+  return embedCodesPage(context, baseUrl, assetContext, '', opts.embedCodesHtmlTemplate, cb);
 }
 
 
 /*
  * Generate embed codes
  */
-function embedCodesPage(context, baseUrl, assetContext, path, _cb) {
+function embedCodesPage(context, baseUrl, assetContext, path, embedCodesHtmlTemplate, _cb) {
 
   // for dev builds baseUrl is always localhost
   var urlPath = path.substring(1) + '/';
   var embedUrl = context.dev ? ('http://localhost:3000/' + urlPath) : baseUrl + assetContext + urlPath;
   var embedBaseUrl = context.dev ? ('http://localhost:3000/') : baseUrl + assetContext;
 
-  var templatePath = require.resolve('../../src/www/embed-codes.hbs');
+  var templatePath = embedCodesHtmlTemplate || require.resolve('../../src/www/embed-codes.hbs');
 
   return src(templatePath)
     .pipe(through2.obj(function(file, _enc, _cb) {

--- a/src/js/prepare-build-tasks.js
+++ b/src/js/prepare-build-tasks.js
@@ -316,7 +316,6 @@ var prepareBuildTasks = function(gulp, opts) {
   gulp.task('bundle-embed-bootstrap', bundleEmbedBootstrap.bind(null, context, deployOpt.assetContext));
   gulp.task('bundle-resize', bundleResize.bind(null, context, opts.assetContext));
   gulp.task('embed-codes', embedCodeUtils.embedCodes.bind(null, context, opts, deployOpt.baseUrl, deployOpt.assetContext));
-  //gulp.task('serve-prod', buildTools.serveProd);
   gulp.task('setup-dist-build', setupDistBuild);
   gulp.task('notify', notify.bind(null, deployOpt.project,
       deployOpt.org,

--- a/src/js/prepare-build-tasks.js
+++ b/src/js/prepare-build-tasks.js
@@ -132,10 +132,8 @@ var createJsxAndBundlePromisified = Promise.promisify(createJsxAndBundle);
  */
 function generateJSX(reactRouter, componentPath, tempFileName) {
   var bootstrapper = './bootstrap-component.jsx';
-  //var bootstrapper = require.resolve('./react-bootstrap/bootstrap-component.jsx');
   if (reactRouter) {
     bootstrapper = './bootstrap-react-router-component.jsx';
-    //bootstrapper = require.resolve('./react-bootstrap/bootstrap-react-router-component.jsx');
   }
   var templateFile = require.resolve('./react-bootstrap/component-template.jsx');
   var template = fs.readFileSync(templateFile, 'utf8');

--- a/src/js/prepare-build-tasks.js
+++ b/src/js/prepare-build-tasks.js
@@ -101,17 +101,22 @@ function generateMetaData(path) {
  * Create JSX and run webpack to create the associated bundle
  *
  * destPath      -- path below which all files are created
- * componentPath -- path to React component to be bundled
+ * entryPoint    -- path to entry point for bundle
+ * componentPath -- path to React component to be bundled (only applies if entry point not defined)
  * reactRouter   -- enable react-router
  * pageDefs      -- page definitions for creating associated html files
  * watch         -- start watching with webback-dev-server
  *
  */
-function createJsxAndBundle(destPath, componentPath, reactRouter, pageDefs, watch, assetContext, babelPaths, callback) {
-  var tempFileName = getTempFileName(componentPath);
-  generateJSX(reactRouter, componentPath, tempFileName);
+function createJsxAndBundle(destPath, entryPoint, componentPath, reactRouter, pageDefs, watch, assetContext, babelPaths, callback) {
+
+  if (!entryPoint) {
+    var tempFileName = getTempFileName(componentPath);
+    generateJSX(reactRouter, componentPath, tempFileName);
+    entryPoint = './temp/' + tempFileName;
+  }
+
   generateMetaData(destPath);
-  var entryPoint = './temp/' + tempFileName;
   bundleWebpack(
     entryPoint,
     null,
@@ -160,7 +165,7 @@ function bundleComponents(opts, context, assetContext, callback) {
   if (!opts.embedDefs) {
     var watch = context.dev; // TODO
     var componentPath = 'index.js';
-    createJsxAndBundle(context.destPath, componentPath,
+    createJsxAndBundle(context.destPath, opts.entryPoint, componentPath,
       opts.reactRouter, pageDefs, watch, assetContext, opts.babelPaths, callback);
     return;
   }
@@ -176,7 +181,7 @@ function bundleComponents(opts, context, assetContext, callback) {
     var watch = false;
     var pageDef = pageDefUtils.enrichPageDef(edef, opts.baseUrl, assetContext);
     pageDef.path = '';
-    return createJsxAndBundlePromisified(destPath, edef.componentPath,
+    return createJsxAndBundlePromisified(destPath, null, edef.componentPath,
       opts.reactRouter, [pageDef], watch, assetContext + edef.path.substring(1) + '/', opts.babelPaths);
   });
 

--- a/src/www/embed.hbs
+++ b/src/www/embed.hbs
@@ -20,11 +20,11 @@
   {{/if}}
 
   <!-- Schema.org markup for Google+ -->
-  {{#if htmlWebpackPlugin.optionstitle}}
+  {{#if htmlWebpackPlugin.options.title}}
   <meta itemprop="name" content="{{{htmlWebpackPlugin.options.title}}}">
   {{/if}}
 
-  {{#if htmlWebpackPlugin.optionsdescription}}
+  {{#if htmlWebpackPlugin.options.description}}
     <meta itemprop="description" content="{{{htmlWebpackPlugin.options.description}}}">
   {{/if}}
 

--- a/test-projects/templates-test-project/.gitignore
+++ b/test-projects/templates-test-project/.gitignore
@@ -1,0 +1,10 @@
+
+build/
+dist
+node_modules/*
+!node_modules/module1
+temp/*.js
+temp/*.jsx
+temp/asset-manifest.json
+.awspublish*
+npm-debug.log

--- a/test-projects/templates-test-project/README.md
+++ b/test-projects/templates-test-project/README.md
@@ -1,0 +1,5 @@
+
+# Test project
+
+Simple test project for testing basic `lucify-component-builder` functionality. 
+Currently only creates a simple build for visual testing. We will add unit tests once API is more stable.

--- a/test-projects/templates-test-project/gulpfile.js
+++ b/test-projects/templates-test-project/gulpfile.js
@@ -1,0 +1,15 @@
+
+var path = require('path');
+var gulp = require('gulp');
+
+var opts = {
+  pageDef: {
+    indexHtmlTemplate: path.resolve('src/www/index-template.hbs')
+  },
+  embedCodesHtmlTemplate: path.resolve('src/www/embed-codes-template.hbs'),
+  entryPoint: path.resolve('src/js/components/entry-point.jsx'),
+  assetContext: 'hello-world/'
+};
+
+var builder = require('../../index.js'); // lucify-component-builder
+builder(gulp, opts);

--- a/test-projects/templates-test-project/index.js
+++ b/test-projects/templates-test-project/index.js
@@ -1,0 +1,2 @@
+
+module.exports = require('./src/js/components/hello-world.jsx');

--- a/test-projects/templates-test-project/package.json
+++ b/test-projects/templates-test-project/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "templates-test-project",
+  "version": "0.0.1",
+  "description": "Test project for lucify-component-builder",
+  "main": "index.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lucified/lucify-component-builder.git"
+  },
+  "scripts": {
+    "start": "gulp",
+    "test": "gulp dist",
+    "postinstall": "rm -rf node_modules/lucify-component-builder && ln -sf ../../../ node_modules/lucify-component-builder"
+  },
+  "engines": {
+    "node": ">=4.0.0"
+  },
+  "license": "",
+  "dependencies": {
+    "babelify": "^6.4.0",
+    "gulp": "gulpjs/gulp#4.0",
+    "react": "~15.0.1",
+    "react-dom": "~15.0.1"
+  },
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
+  }
+}

--- a/test-projects/templates-test-project/src/js/components/entry-point.jsx
+++ b/test-projects/templates-test-project/src/js/components/entry-point.jsx
@@ -1,0 +1,8 @@
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import HelloWorld from './hello-world.jsx';
+
+window.React = React;
+ReactDOM.render(<HelloWorld />, document.getElementById('content'));

--- a/test-projects/templates-test-project/src/js/components/hello-world.jsx
+++ b/test-projects/templates-test-project/src/js/components/hello-world.jsx
@@ -1,0 +1,24 @@
+
+import React from 'react';
+
+var HelloWorld = () => {
+
+  return (
+    <div>
+      <h2>Hello World</h2>
+      <div>
+        <ul>
+          <li>This index.html should contain a comment with contents 'HELLO'</li>
+          <li>The <a href="embed-codes.html">embed-codes.html</a> page should
+          contain a comment with contents 'HELLO EMBED CODES'. Note that
+          the page is not available when running on webpack-dev-server. It only
+          exists within distribution builds.</li>
+        </ul>
+      </div>
+    </div>
+  );
+
+};
+
+HelloWorld.displayName = 'Hello World';
+export default HelloWorld;

--- a/test-projects/templates-test-project/src/www/embed-codes-template.hbs
+++ b/test-projects/templates-test-project/src/www/embed-codes-template.hbs
@@ -1,0 +1,117 @@
+<!doctype html>
+<html class="no-js" lang="">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Embed Codes</title>
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700|Montserrat:400,700'
+  rel='stylesheet' type='text/css'>
+
+  <link rel="stylesheet" type="text/css" href="/{{{assetPath 'styles.css'}}}">
+
+  <!-- HELLO EMBED CODES -->
+
+<body>
+
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-65400709-1', 'auto');
+    ga('send', 'pageview');
+  </script>
+
+<style>
+
+body {
+  font-family: 'Open Sans', sans-serif;
+  font-size: 12px;
+}
+
+.embed-code {
+  width: 100%;
+  color: #18b7b7;
+  border: 2px solid #cdcccc;
+  border-radius: 5px;
+  font-size: 1.0rem;
+  padding: 0.6rem;
+  box-sizing: border-box;
+  margin-bottom: 2rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+h3 {
+  font-family: 'Montserrat', sans-serif;
+  margin-bottom: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.main {
+  padding: 1.5rem;
+  max-width: 60rem;
+}
+
+/*  font-family: 'Montserrat', sans-serif; */
+
+
+
+</style>
+
+<div class="main">
+
+<h2>Embed codes</h2>
+
+<h3>1. Recommended</h3>
+<textarea class="embed-code">{{scriptTagEmbedCode}}</textarea>
+
+<h3>2. IFrame tag with remote auto-resize script</h3>
+<textarea class="embed-code" rows="3">{{iFrameWithRemoteResizeEmbedCode}}</textarea>
+
+<h3>3. IFrame tag with inline auto-resize script</h3>
+<textarea class="embed-code" rows="10">{{iFrameWithInlineResizeEmbedCode}}</textarea>
+
+<p>
+  All embed code types will embed the
+  Lucify component within an iFrame.
+</p>
+
+<p>Use Lucify embeds at your own risk.</p>
+
+<p>
+  To inject an embed for testing with Chrome's
+  web developer tools:
+  <ol>
+    <li>
+      Insert the iFrame part of the embed code (3)
+      into the desired location in the page.
+    </li>
+    <li>
+      Copy-paste the script part of embed code (3)
+      into the console.
+    </li>
+  </ol>
+</p>
+
+<p>Resizing is based on <a href="https://github.com/davidjbradshaw/iframe-resizer">iframe-resizer</a>.</p>
+
+<p>Contact info@lucify.com if you have any question or require assistance.</p>
+
+</div>
+
+
+
+
+
+</body>
+
+</html>

--- a/test-projects/templates-test-project/src/www/index-template.hbs
+++ b/test-projects/templates-test-project/src/www/index-template.hbs
@@ -1,0 +1,162 @@
+<!doctype html>
+<html class="no-js" lang="">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>{{{htmlWebpackPlugin.options.title}}}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- HELLO -->
+
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700|Montserrat:400,700'
+  rel='stylesheet' type='text/css'>
+
+  {{#if htmlWebpackPlugin.options.url}}
+  <link rel="canonical" href="{{{htmlWebpackPlugin.options.url}}}" />
+  {{/if}}
+
+
+  {{#if htmlWebpackPlugin.options.description}}
+    <meta name="description" content="{{{htmlWebpackPlugin.options.description}}}" />
+  {{/if}}
+
+  <!-- Schema.org markup for Google+ -->
+  {{#if htmlWebpackPlugin.options.title}}
+  <meta itemprop="name" content="{{{htmlWebpackPlugin.options.title}}}">
+  {{/if}}
+
+  {{#if htmlWebpackPlugin.options.description}}
+    <meta itemprop="description" content="{{{htmlWebpackPlugin.options.description}}}">
+  {{/if}}
+
+  {{#if htmlWebpackPlugin.options.schemaImage}}
+    <meta itemprop="image" content="{{{htmlWebpackPlugin.options.schemaImage}}}">
+  {{/if}}
+
+  {{#if htmlWebpackPlugin.options.description}}
+    <!-- Twitter Card data -->
+    <meta name="twitter:card" content="summary_large_image">
+
+    {{#if htmlWebpackPlugin.options.twitterSite}}
+    <meta name="twitter:site" content="{{{htmlWebpackPlugin.options.twitterSite}}}">
+    {{/if}}
+
+    {{#if htmlWebpackPlugin.options.title}}
+    <meta name="twitter:title" content="{{{htmlWebpackPlugin.options.title}}}">
+    {{/if}}
+
+    {{#if htmlWebpackPlugin.options.description}}
+    <meta name="twitter:description" content="{{{htmlWebpackPlugin.options.description}}}">
+    {{/if}}
+
+    {{#if htmlWebpackPlugin.options.twitterCreator}}
+    <meta name="twitter:creator" content="{{{htmlWebpackPlugin.options.twitterCreator}}}">
+    {{/if}}
+    <!-- must be at least 280x150px -->
+    {{#if htmlWebpackPlugin.options.twitterImage}}
+    <meta name="twitter:image:src" content="{{{htmlWebpackPlugin.options.twitterImage}}}">
+    {{/if}}
+
+  {{/if}}
+
+  <!-- Open Graph data -->
+  {{#if htmlWebpackPlugin.options.title}}
+  <meta property="og:title" content="{{{htmlWebpackPlugin.options.title}}}" />
+  {{/if}}
+
+  {{#if htmlWebpackPlugin.options.ogType}}
+  <meta property="og:type" content="{{{htmlWebpackPlugin.options.ogType}}}" />
+  {{/if}}
+
+  {{#if htmlWebpackPlugin.options.url}}
+  <meta property="og:url" content="{{{htmlWebpackPlugin.options.url}}}" />
+  {{/if}}
+
+  {{#if htmlWebpackPlugin.options.openGraphImage}}
+    <meta property="og:image" content="{{{htmlWebpackPlugin.options.openGraphImage}}}" />
+  {{/if}}
+
+  {{#if htmlWebpackPlugin.options.description}}
+    <meta property="og:description" content="{{{htmlWebpackPlugin.options.description}}}" />
+  {{/if}}
+
+  {{#if htmlWebpackPlugin.options.ogSiteName}}
+  <meta property="og:site_name" content="{{{htmlWebpackPlugin.options.ogSiteName}}}" />
+  {{/if}}
+
+  {{#if htmlWebpackPlugin.options.fbAppId}}
+  <meta property="fb:app_id" content="{{{htmlWebpackPlugin.options.fbAppId}}}" />
+  {{/if}}
+
+
+  {{#if htmlWebpackPlugin.options.iFrameResize}}
+  <script>
+  /*! iFrame Resizer (iframeSizer.contentWindow.min.js) - v2.8.10 - 2015-06-21
+   *  Desc: Include this file in any page being loaded into an iframe
+   *        to force the iframe to resize to the content size.
+   *  Requires: iframeResizer.min.js on host page.
+   *  Copyright: (c) 2015 David J. Bradshaw - dave@bradshaw.net
+   *  License: MIT
+   */
+  !function(){"use strict";function a(a,b,c){"addEventListener"in window?a.addEventListener(b,c,!1):"attachEvent"in window&&a.attachEvent("on"+b,c)}function b(a){return aa+"["+ca+"] "+a}function c(a){_&&"object"==typeof window.console&&console.log(b(a))}function d(a){"object"==typeof window.console&&console.warn(b(a))}function e(){c("Initialising iFrame"),f(),i(),h("background",M),h("padding",P),o(),m(),j(),q(),n(),Z=p(),E("init","Init message from host page")}function f(){function a(a){return"true"===a?!0:!1}var b=Y.substr(ba).split(":");ca=b[0],N=void 0!==b[1]?Number(b[1]):N,Q=void 0!==b[2]?a(b[2]):Q,_=void 0!==b[3]?a(b[3]):_,$=void 0!==b[4]?Number(b[4]):$,da=void 0!==b[5]?a(b[5]):da,K=void 0!==b[6]?a(b[6]):K,O=b[7],W=void 0!==b[8]?b[8]:W,M=b[9],P=b[10],ia=void 0!==b[11]?Number(b[11]):ia,Z.enable=void 0!==b[12]?a(b[12]):!1,fa=void 0!==b[13]?b[13]:fa}function g(a,b){return-1!==b.indexOf("-")&&(d("Negative CSS value ignored for "+a),b=""),b}function h(a,b){void 0!==b&&""!==b&&"null"!==b&&(document.body.style[a]=b,c("Body "+a+' set to "'+b+'"'))}function i(){void 0===O&&(O=N+"px"),g("margin",O),h("margin",O)}function j(){document.documentElement.style.height="",document.body.style.height="",c('HTML & body height set to "auto"')}function k(b){function d(c){a(window,c,function(){E(b.eventName,b.eventType)})}b.eventNames&&Array.prototype.map?(b.eventName=b.eventNames[0],b.eventNames.map(d)):d(b.eventName),c("Added event listener: "+b.eventType)}function l(){k({eventType:"Animation Start",eventNames:["animationstart","webkitAnimationStart"]}),k({eventType:"Animation Iteration",eventNames:["animationiteration","webkitAnimationIteration"]}),k({eventType:"Animation End",eventNames:["animationend","webkitAnimationEnd"]}),k({eventType:"Device Orientation Change",eventName:"orientationchange"}),k({eventType:"Transition End",eventNames:["transitionend","webkitTransitionEnd","MSTransitionEnd","oTransitionEnd","otransitionend"]}),k({eventType:"Window Clicked",eventName:"click"}),"child"===fa&&k({eventType:"IFrame Resized",eventName:"resize"})}function m(){V!==W&&(W in ma||(d(W+" is not a valid option for heightCalculationMethod."),W="bodyScroll"),c('Height calculation method set to "'+W+'"'))}function n(){!0===K?(l(),t()):c("Auto Resize disabled")}function o(){var a=document.createElement("div");a.style.clear="both",a.style.display="block",document.body.appendChild(a)}function p(){function b(){return{x:void 0!==window.pageXOffset?window.pageXOffset:document.documentElement.scrollLeft,y:void 0!==window.pageYOffset?window.pageYOffset:document.documentElement.scrollTop}}function e(a){var c=a.getBoundingClientRect(),d=b();return{x:parseInt(c.left,10)+parseInt(d.x,10),y:parseInt(c.top,10)+parseInt(d.y,10)}}function f(a){function b(a){var b=e(a);c("Moving to in page link (#"+d+") at x: "+b.x+" y: "+b.y),I(b.y,b.x,"scrollToOffset")}var d=a.split("#")[1]||"",f=decodeURIComponent(d),g=document.getElementById(f)||document.getElementsByName(f)[0];g?b(g):(c("In page link (#"+d+") not found in iFrame, so sending to parent"),I(0,0,"inPageLink","#"+d))}function g(){""!==location.hash&&"#"!==location.hash&&f(location.href)}function h(){function b(b){function c(a){a.preventDefault(),f(this.getAttribute("href"))}"#"!==b.getAttribute("href")&&a(b,"click",c)}Array.prototype.forEach.call(document.querySelectorAll('a[href^="#"]'),b)}function i(){a(window,"hashchange",g)}function j(){setTimeout(g,S)}function k(){Array.prototype.forEach&&document.querySelectorAll?(c("Setting up location.hash handlers"),h(),i(),j()):d("In page linking not fully supported in this browser! (See README.md for IE8 workaround)")}return Z.enable?k():c("In page linking not enabled"),{findTarget:f}}function q(){da&&(c("Enable public methods"),window.parentIFrame={close:function(){I(0,0,"close")},getId:function(){return ca},moveToAnchor:function(a){Z.findTarget(a)},reset:function(){H("parentIFrame.reset")},scrollTo:function(a,b){I(b,a,"scrollTo")},scrollToOffset:function(a,b){I(b,a,"scrollToOffset")},sendMessage:function(a,b){I(0,0,"message",JSON.stringify(a),b)},setHeightCalculationMethod:function(a){W=a,m()},setTargetOrigin:function(a){c("Set targetOrigin: "+a),ga=a},size:function(a,b){var c=""+(a?a:"")+(b?","+b:"");F(),E("size","parentIFrame.size("+c+")",a,b)}})}function r(){0!==$&&(c("setInterval: "+$+"ms"),setInterval(function(){E("interval","setInterval: "+$)},Math.abs($)))}function s(b){function d(b){(void 0===b.height||void 0===b.width||0===b.height||0===b.width)&&(c("Attach listerner to "+b.src),a(b,"load",function(){E("imageLoad","Image loaded")}))}b.forEach(function(a){if("attributes"===a.type&&"src"===a.attributeName)d(a.target);else if("childList"===a.type){var b=a.target.querySelectorAll("img");Array.prototype.forEach.call(b,function(a){d(a)})}})}function t(){function a(){var a=document.querySelector("body"),d={attributes:!0,attributeOldValue:!1,characterData:!0,characterDataOldValue:!1,childList:!0,subtree:!0},e=new b(function(a){E("mutationObserver","mutationObserver: "+a[0].target+" "+a[0].type),s(a)});c("Enable MutationObserver"),e.observe(a,d)}var b=window.MutationObserver||window.WebKitMutationObserver;b?0>$?r():a():(d("MutationObserver not supported in this browser!"),r())}function u(){function a(a){function b(a){var b=/^\d+(px)?$/i;if(b.test(a))return parseInt(a,L);var d=c.style.left,e=c.runtimeStyle.left;return c.runtimeStyle.left=c.currentStyle.left,c.style.left=a||0,a=c.style.pixelLeft,c.style.left=d,c.runtimeStyle.left=e,a}var c=document.body,d=0;return"defaultView"in document&&"getComputedStyle"in document.defaultView?(d=document.defaultView.getComputedStyle(c,null),d=null!==d?d[a]:0):d=b(c.currentStyle[a]),parseInt(d,L)}return document.body.offsetHeight+a("marginTop")+a("marginBottom")}function v(){return document.body.scrollHeight}function w(){return document.documentElement.offsetHeight}function x(){return document.documentElement.scrollHeight}function y(){for(var a=document.querySelectorAll("body *"),b=a.length,d=0,e=(new Date).getTime(),f=0;b>f;f++)a[f].getBoundingClientRect().bottom>d&&(d=a[f].getBoundingClientRect().bottom);return e=(new Date).getTime()-e,c("Parsed "+b+" HTML elements"),c("LowestElement bottom position calculated in "+e+"ms"),d}function z(){return[u(),v(),w(),x()]}function A(){return Math.max.apply(null,z())}function B(){return Math.min.apply(null,z())}function C(){return Math.max(u(),y())}function D(){return Math.max(document.documentElement.scrollWidth,document.body.scrollWidth)}function E(a,b,d,e){function f(){a in{reset:1,resetPage:1,init:1}||c("Trigger event: "+b)}function g(){U=n,la=o,I(U,la,a)}function h(){return ja&&a in R}function i(){function a(a,b){var c=Math.abs(a-b)<=ia;return!c}return n=void 0!==d?d:ma[W](),o=void 0!==e?e:D(),a(U,n)||Q&&a(la,o)}function j(){return!(a in{init:1,interval:1,size:1})}function k(){return W in ea}function l(){c("No change in size detected")}function m(){j()&&k()?H(b):a in{interval:1}||(f(),l())}var n,o;h()?c("Trigger event cancelled: "+a):i()||"init"===a?(f(),F(),g()):m()}function F(){ja||(ja=!0,c("Trigger event lock on")),clearTimeout(ka),ka=setTimeout(function(){ja=!1,c("Trigger event lock off"),c("--")},S)}function G(a){U=ma[W](),la=D(),I(U,la,a)}function H(a){var b=W;W=V,c("Reset trigger event: "+a),F(),G("reset"),W=b}function I(a,b,d,e,f){function g(){void 0===f?f=ga:c("Message targetOrigin: "+f)}function h(){var g=a+":"+b,h=ca+":"+g+":"+d+(void 0!==e?":"+e:"");c("Sending message to host page ("+h+")"),ha.postMessage(aa+h,f)}g(),h()}function J(a){function b(){return aa===(""+a.data).substr(0,ba)}function f(){Y=a.data,ha=a.source,e(),T=!1,setTimeout(function(){X=!1},S)}function g(){X?c("Page reset ignored by init"):(c("Page size reset by host page"),G("resetPage"))}function h(){E("resizeParent","Parent window resized")}function i(){return a.data.split("]")[1]}function j(){return"iFrameResize"in window}function k(){return a.data.split(":")[2]in{"true":1,"false":1}}if(b())if(!1===T)switch(i()){case"reset":g();break;case"resize":h();break;default:j()||d("Unexpected message ("+a.data+")")}else k()?f():c('Ignored message of type "'+i()+'". Received before initialization.')}var K=!0,L=10,M="",N=0,O="",P="",Q=!1,R={resize:1,click:1},S=128,T=!0,U=1,V="offset",W=V,X=!0,Y="",Z={},$=32,_=!1,aa="[iFrameSizer]",ba=aa.length,ca="",da=!1,ea={max:1,scroll:1,bodyScroll:1,documentElementScroll:1},fa="child",ga="*",ha=window.parent,ia=0,ja=!1,ka=null,la=1,ma={offset:u,bodyOffset:u,bodyScroll:v,documentElementOffset:w,scroll:x,documentElementScroll:x,max:A,min:B,grow:A,lowestElement:C};a(window,"message",J)}();
+    //# sourceMappingURL=iframeResizer.contentWindow.map
+  </script>
+  {{/if}}
+
+</head>
+
+<body>
+
+  <div id='content'>
+
+  </div>
+
+  {{#if htmlWebpackPlugin.options.googleAnalytics}}
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-65400709-1', 'auto');
+
+  </script>
+  {{/if}}
+
+  {{#if htmlWebpackPlugin.options.googleAnalyticsSendPageView}}
+  <script>
+    ga('send', 'pageview');
+  </script>
+  {{/if}}
+
+
+{{#if htmlWebpackPlugin.options.riveted}}
+<script>
+  /*!
+ * @preserve
+ * riveted.js | v0.6.0
+ * Copyright (c) 2015 Rob Flaherty (@robflaherty)
+ * Licensed under the MIT license
+ */
+var riveted=function(){function e(e){e=e||{},g=parseInt(e.reportInterval,10)||5,p=parseInt(e.idleTimeout,10)||30,k=e.gaGlobal||"ga","function"==typeof window[k]&&(y=!0),"undefined"!=typeof _gaq&&"function"==typeof _gaq.push&&(w=!0),"undefined"!=typeof dataLayer&&"function"==typeof dataLayer.push&&(h=!0),I="gaTracker"in e&&"string"==typeof e.gaTracker?e.gaTracker+".send":"send","function"==typeof e.eventHandler&&(s=e.eventHandler),"function"==typeof e.userTimingHandler&&(m=e.userTimingHandler),T="nonInteraction"in e&&(e.nonInteraction===!1||"false"===e.nonInteraction)?!1:!0,t(document,"keydown",f),t(document,"click",f),t(window,"mousemove",n(f,500)),t(window,"scroll",n(f,500)),t(document,"visibilitychange",a),t(document,"webkitvisibilitychange",a)}function n(e,n){var t,i,a,o=null,r=0,u=function(){r=new Date,o=null,a=e.apply(t,i)};return function(){var c=new Date;r||(r=c);var d=n-(c-r);return t=this,i=arguments,0>=d?(clearTimeout(o),o=null,r=c,a=e.apply(t,i)):o||(o=setTimeout(u,d)),a}}function t(e,n,t){e.addEventListener?e.addEventListener(n,t,!1):e.attachEvent?e.attachEvent("on"+n,t):e["on"+n]=t}function i(){clearTimeout(H),r()}function a(){(document.hidden||document.webkitHidden)&&i()}function o(){_+=1,_>0&&_%g===0&&s(_)}function r(){L=!0,clearTimeout(E)}function u(){i(),b=!0}function c(){b=!1}function d(){L=!1,clearTimeout(E),E=setInterval(o,1e3)}function l(){var e=new Date,n=e-D;R=!0,m(n),E=setInterval(o,1e3)}function v(){D=new Date,_=0,R=!1,L=!1,clearTimeout(E),clearTimeout(H)}function f(){b||(R||l(),L&&d(),clearTimeout(H),H=setTimeout(i,1e3*p+100))}var s,m,g,p,T,y,w,I,h,k,R=!1,L=!1,b=!1,_=0,D=new Date,E=null,H=null;return m=function(e){h?dataLayer.push({event:"RivetedTiming",eventCategory:"Riveted",timingVar:"First Interaction",timingValue:e}):(y&&window[k](I,"timing","Riveted","First Interaction",e),w&&_gaq.push(["_trackTiming","Riveted","First Interaction",e,null,100]))},s=function(e){h?dataLayer.push({event:"Riveted",eventCategory:"Riveted",eventAction:"Time Spent",eventLabel:e,eventValue:g,eventNonInteraction:T}):(y&&window[k](I,"event","Riveted","Time Spent",e.toString(),g,{nonInteraction:T}),w&&_gaq.push(["_trackEvent","Riveted","Time Spent",e.toString(),g,T]))},{init:e,trigger:f,setIdle:i,on:c,off:u,reset:v}}();
+  </script>
+  <script>riveted.init({reportInterval: 10, nonInteraction: false});</script>
+{{/if}}
+
+
+{{#if htmlWebpackPlugin.options.adsByGoogle}}
+  <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js">
+  </script>
+{{/if}}
+
+<script src="{{{htmlWebpackPlugin.files.chunks.main.entry}}}"></script>
+
+{{#if htmlWebpackPlugin.options.devServer}}
+<script src="http://localhost:3000/webpack-dev-server.js"></script>
+{{/if}}
+
+
+</body>
+
+</html>

--- a/test/tests.js
+++ b/test/tests.js
@@ -189,4 +189,13 @@ describe('build test projects', () => {
     done();
   });
 
+  it('creates basic assets for templates-test-project', done => {
+    'test-projects/templates-test-project/dist/hello-world/lucify-metadata.json'.should.be.a.file().with.json;
+    'test-projects/templates-test-project/dist/hello-world/index.html'.should.be.a.file().and.not.empty;
+    'test-projects/templates-test-project/dist/hello-world/embed-codes.html'.should.be.a.file().and.not.empty;
+    'test-projects/templates-test-project/dist/hello-world/index.html'.should.have.content.that.match(/HELLO/);
+    'test-projects/templates-test-project/dist/hello-world/embed-codes.html'.should.have.content.that.match(/HELLO EMBED/);
+    done();
+  });
+
 });


### PR DESCRIPTION
Add support for providing templates for 
- `index.html`
- `embed-codes.html`

Also adds support for providing directly the entry point for the javascript bundle. With this option any version of React can be used (or any other library).

Take a look at `templates-test-project` for example usage.
