### PR TITLE
Remove dependency on lucify-commons

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "less-loader": "^2.2.2",
     "libsodium-wrappers": "^0.2.12",
     "lodash": "^4.4.0",
-    "lucify-embed-code": "~0.1.1",
+    "lucify-embed-code": "~0.1.2",
     "merge-stream": "^1.0.0",
     "minimist": "^1.2.0",
     "mkpath": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "less-loader": "^2.2.2",
     "libsodium-wrappers": "^0.2.12",
     "lodash": "^4.4.0",
-    "lucify-commons": "~0.2.3",
     "merge-stream": "^1.0.0",
     "minimist": "^1.2.0",
     "mkpath": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "less-loader": "^2.2.2",
     "libsodium-wrappers": "^0.2.12",
     "lodash": "^4.4.0",
+    "lucify-embed-code": "~0.1.1",
     "merge-stream": "^1.0.0",
     "minimist": "^1.2.0",
     "mkpath": "^1.0.0",

--- a/src/js/embed-code-utils.js
+++ b/src/js/embed-code-utils.js
@@ -3,7 +3,8 @@ var gulp = require('gulp');
 var through2 = require('through2');
 var $ = require('gulp-load-plugins')();
 var mergeStream = require('merge-stream');
-var embedCode = require('lucify-commons/src/js/embed-code.js');
+var embedCode = require('lucify-embed-code');
+
 
 var src  = gulp.src;
 var dest = gulp.dest;

--- a/test-projects/multi-embed-test-project/gulpfile.js
+++ b/test-projects/multi-embed-test-project/gulpfile.js
@@ -18,7 +18,6 @@ var embedDefs = [
 
 var opts = {
   embedDefs: embedDefs,
-  babelPaths: [require.resolve('lucify-commons').replace('index.js', 'src')],
   publishFromFolder: 'dist',
   assetContext: 'embed/',
 };

--- a/test-projects/multi-embed-test-project/package.json
+++ b/test-projects/multi-embed-test-project/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "babelify": "^6.4.0",
     "gulp": "gulpjs/gulp#4.0",
-    "lucify-commons": "~0.2.2",
     "react": "0.13.3"
   },
   "browserify": {

--- a/test-projects/multi-embed-test-project/src/js/components/hello-world-two.jsx
+++ b/test-projects/multi-embed-test-project/src/js/components/hello-world-two.jsx
@@ -1,7 +1,5 @@
 
 var React = require('react');
-var assets = require('lucify-commons/src/js/lucify-assets.js');
-
 var url50e = require('../../images/50euro.jpg');
 
 
@@ -12,12 +10,10 @@ var HelloWorld2 = React.createClass({
     return (
       <div className="hello-world">
 
-        <div className="inputs">
-          <div className="lucify-container">
-
-              <h2>Hello World 2</h2>
-              <img src={url50e} style={{width: "100%"}} />
-
+        <div>
+          <div>
+            <h2>Hello World 2</h2>
+            <img src={url50e} style={{width: "100%"}} />
           </div>
         </div>
 

--- a/test-projects/multi-embed-test-project/src/js/components/hello-world.jsx
+++ b/test-projects/multi-embed-test-project/src/js/components/hello-world.jsx
@@ -1,8 +1,6 @@
 
 var React = require('react');
 
-var DividedCols = require('lucify-commons/src/js/components/divided-cols.jsx');
-
 var url20e = require('../../images/50euro.jpg');
 var url50e = require('../../../temp/generated-images/20euro.jpg');
 var url100e = require('module1/src/images/100euro.jpg');
@@ -18,34 +16,30 @@ var HelloWorld = React.createClass({
     return (
       <div className={styles['hello-world']}>
 
-        <div className="inputs">
-          <div className="lucify-container">
+        <div>
+          <div>
 
               <h2>Hello World</h2>
 
               <h3>Images</h3>
 
-              <DividedCols
-              first={
-                <div>
-                  <h4>Images from project</h4>
-                  <p>50 euro image from src/images/</p>
-                  <img src={url50e} style={{width: "100%"}} />
+              <div>
+                <h4>Images from project</h4>
+                <p>50 euro image from src/images/</p>
+                <img src={url50e} style={{width: "100%"}} />
 
-                  <p>20 euro image from temp/generated-images/</p>
-                  <img src={url20e} style={{width: "100%"}} />
-                </div>
-              }
-              second={
-                <div>
-                  <h4>Images from dependencies</h4>
-                  <p>100 euro image from test_modules/module1/src/images/</p>
-                  <img src={url100e} style={{width: "100%"}} />
+                <p>20 euro image from temp/generated-images/</p>
+                <img src={url20e} style={{width: "100%"}} />
+              </div>
 
-                  <p>200 euro image from test_modules/module1/temp/generated-images/</p>
-                  <img src={url200e} style={{width: "100%"}} />
-                </div>
-              } />
+              <div>
+                <h4>Images from dependencies</h4>
+                <p>100 euro image from test_modules/module1/src/images/</p>
+                <img src={url100e} style={{width: "100%"}} />
+
+                <p>200 euro image from test_modules/module1/temp/generated-images/</p>
+                <img src={url200e} style={{width: "100%"}} />
+              </div>
 
           </div>
         </div>

--- a/test-projects/multi-embed-test-project/src/scss/styles.scss
+++ b/test-projects/multi-embed-test-project/src/scss/styles.scss
@@ -1,6 +1,4 @@
 
-@import '../../node_modules/lucify-commons/src/scss/styles-full.scss';
-
 .hello-world {
 
   h2 {
@@ -19,10 +17,6 @@
   h4 {
     font-size: 1.0rem;
     font-weight: normal;
-  }
-
-  p {
-    @include lucify-medium-paragraph()
   }
 
 }

--- a/test-projects/multi-page-test-project/gulpfile.js
+++ b/test-projects/multi-page-test-project/gulpfile.js
@@ -22,7 +22,6 @@ var defs = [
 
 
 var opts = {
-  babelPaths: [require.resolve('lucify-commons').replace('index.js', 'src')],
   publishFromFolder: 'dist',
   assetContext: 'test-path/',
   pageDefs: defs,

--- a/test-projects/multi-page-test-project/package.json
+++ b/test-projects/multi-page-test-project/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "babelify": "^6.4.0",
     "gulp": "gulpjs/gulp#4.0",
-    "lucify-commons": "~0.2.2",
     "react": "0.13.3"
   },
   "browserify": {

--- a/test-projects/multi-page-test-project/src/js/components/hello-world.jsx
+++ b/test-projects/multi-page-test-project/src/js/components/hello-world.jsx
@@ -1,9 +1,6 @@
 
 var React = require('react');
 
-var DividedCols = require('lucify-commons/src/js/components/divided-cols.jsx');
-var NiceSlider = require('lucify-commons/src/js/components/nice-slider.jsx');
-
 var url20e = require('../../images/50euro.jpg');
 var url50e = require('../../../temp/generated-images/20euro.jpg');
 var url100e = require('module1/src/images/100euro.jpg');
@@ -19,35 +16,28 @@ var HelloWorld = React.createClass({
     return (
       <div className={styles['hello-world']}>
 
-        <div className="inputs">
-          <div className="lucify-container">
+        <div>
+          <div>
+            <h2>Hello World</h2>
 
-              <h2>Hello World</h2>
+            <h3>Images</h3>
+            <div>
+              <h4>Images from project</h4>
+              <p>50 euro image from src/images/</p>
+              <img src={url50e} style={{width: "100%"}} />
 
-              <h3>Images</h3>
+              <p>20 euro image from temp/generated-images/</p>
+              <img src={url20e} style={{width: "100%"}} />
+            </div>
 
-              <DividedCols
-              first={
-                <div>
-                  <h4>Images from project</h4>
-                  <p>50 euro image from src/images/</p>
-                  <img src={url50e} style={{width: "100%"}} />
+            <div>
+              <h4>Images from dependencies</h4>
+              <p>100 euro image from test_modules/module1/src/images/</p>
+              <img src={url100e} style={{width: "100%"}} />
 
-                  <p>20 euro image from temp/generated-images/</p>
-                  <img src={url20e} style={{width: "100%"}} />
-                </div>
-              }
-              second={
-                <div>
-                  <h4>Images from dependencies</h4>
-                  <p>100 euro image from test_modules/module1/src/images/</p>
-                  <img src={url100e} style={{width: "100%"}} />
-
-                  <p>200 euro image from test_modules/module1/temp/generated-images/</p>
-                  <img src={url200e} style={{width: "100%"}} />
-                </div>
-              } />
-
+              <p>200 euro image from test_modules/module1/temp/generated-images/</p>
+              <img src={url200e} style={{width: "100%"}} />
+            </div>
           </div>
         </div>
 

--- a/test-projects/multi-page-test-project/src/scss/styles.scss
+++ b/test-projects/multi-page-test-project/src/scss/styles.scss
@@ -1,12 +1,4 @@
 
-:global {
-  @import '~lucify-commons/src/scss/styles-full.scss';
-}
-
-// import mixins, etc
-@import '~lucify-commons/src/scss/variables.scss';
-@import '~lucify-commons/src/scss/mixins.scss';
-
 
 .hello-world {
 
@@ -26,10 +18,6 @@
   h4 {
     font-size: 1.0rem;
     font-weight: normal;
-  }
-
-  p {
-    @include lucify-medium-paragraph()
   }
 
 }

--- a/test-projects/single-embed-test-project/gulpfile.js
+++ b/test-projects/single-embed-test-project/gulpfile.js
@@ -2,7 +2,6 @@
 var gulp = require('gulp');
 
 var opts = {
-  babelPaths: [require.resolve('lucify-commons').replace('index.js', 'src')],
   publishFromFolder: 'dist',
   assetContext: 'embed/hello-world/',
 }

--- a/test-projects/single-embed-test-project/package.json
+++ b/test-projects/single-embed-test-project/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "babelify": "^6.4.0",
     "gulp": "gulpjs/gulp#4.0",
-    "lucify-commons": "~0.2.2",
     "react": "0.13.3"
   },
   "browserify": {

--- a/test-projects/single-embed-test-project/src/js/components/hello-world.jsx
+++ b/test-projects/single-embed-test-project/src/js/components/hello-world.jsx
@@ -1,9 +1,6 @@
 
 var React = require('react');
 
-var DividedCols = require('lucify-commons/src/js/components/divided-cols.jsx');
-var NiceSlider = require('lucify-commons/src/js/components/nice-slider.jsx');
-
 var url20e = require('../../images/50euro.jpg');
 var url50e = require('../../../temp/generated-images/20euro.jpg');
 var url100e = require('module1/src/images/100euro.jpg');
@@ -17,35 +14,27 @@ var HelloWorld = React.createClass({
   render: function() {
     return (
        <div className={styles['hello-world']}>
-        <div className="inputs">
-          <div className="lucify-container">
+        <div>
+          <div>
+            <h2>Hello World</h2>
 
-              <h2>Hello World</h2>
+            <h3>Images</h3>
+            <div>
+              <h4>Images from project</h4>
+              <p>50 euro image from src/images/</p>
+              <img src={url50e} style={{width: "100%"}} />
 
-              <h3>Images</h3>
+              <p>20 euro image from temp/generated-images/</p>
+              <img src={url20e} style={{width: "100%"}} />
+            </div>
+            <div>
+              <h4>Images from dependencies</h4>
+              <p>100 euro image from test_modules/module1/src/images/</p>
+              <img src={url100e} style={{width: "100%"}} />
 
-              <DividedCols
-              first={
-                <div>
-                  <h4>Images from project</h4>
-                  <p>50 euro image from src/images/</p>
-                  <img src={url50e} style={{width: "100%"}} />
-
-                  <p>20 euro image from temp/generated-images/</p>
-                  <img src={url20e} style={{width: "100%"}} />
-                </div>
-              }
-              second={
-                <div>
-                  <h4>Images from dependencies</h4>
-                  <p>100 euro image from test_modules/module1/src/images/</p>
-                  <img src={url100e} style={{width: "100%"}} />
-
-                  <p>200 euro image from test_modules/module1/temp/generated-images/</p>
-                  <img src={url200e} style={{width: "100%"}} />
-                </div>
-              } />
-
+              <p>200 euro image from test_modules/module1/temp/generated-images/</p>
+              <img src={url200e} style={{width: "100%"}} />
+            </div>
           </div>
         </div>
       </div>

--- a/test-projects/single-embed-test-project/src/scss/styles.scss
+++ b/test-projects/single-embed-test-project/src/scss/styles.scss
@@ -1,12 +1,4 @@
 
-:global {
-  @import '~lucify-commons/src/scss/styles-full.scss';
-}
-
-// import mixins, etc
-@import '~lucify-commons/src/scss/variables.scss';
-@import '~lucify-commons/src/scss/mixins.scss';
-
 
 .hello-world {
 
@@ -26,10 +18,6 @@
   h4 {
     font-size: 1.0rem;
     font-weight: normal;
-  }
-
-  p {
-    @include lucify-medium-paragraph()
   }
 
 }

--- a/test-projects/single-page-test-project/gulpfile.js
+++ b/test-projects/single-page-test-project/gulpfile.js
@@ -1,19 +1,17 @@
 
 var gulp = require('gulp');
-var template = require('lucify-commons/src/js/lucify-page-def-template.js');
 
 var opts = {
-  pageDef: template.apply({
+  pageDef: {
     title: 'Hello World Title',
     description: 'Hello World description',
     ogType: 'article',
     twitterImage: '50euro.jpg',
     openGraphImage: '100euro.jpg',
     schemaImage: '200euro.jpg'
-  }),
+  },
   iFrameResize: false,
   embedCodes: false,
-  babelPaths: require.resolve('lucify-commons').replace('index.js', 'src'),
   publishFromFolder: 'dist',
   assetContext: 'hello-world/'
 };

--- a/test-projects/single-page-test-project/package.json
+++ b/test-projects/single-page-test-project/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "babelify": "^6.4.0",
     "gulp": "gulpjs/gulp#4.0",
-    "lucify-commons": "~0.2.2",
     "react": "0.13.3"
   },
   "browserify": {

--- a/test-projects/single-page-test-project/src/js/components/hello-world.jsx
+++ b/test-projects/single-page-test-project/src/js/components/hello-world.jsx
@@ -1,9 +1,6 @@
 
 var React = require('react');
 
-var DividedCols = require('lucify-commons/src/js/components/divided-cols.jsx');
-var NiceSlider = require('lucify-commons/src/js/components/nice-slider.jsx');
-
 var url20e = require('../../images/50euro.jpg');
 var url50e = require('../../../temp/generated-images/20euro.jpg');
 
@@ -20,16 +17,12 @@ var HelloWorld = React.createClass({
     return (
       <div className={styles['hello-world']}>
 
-        <div className="inputs">
-          <div className="lucify-container">
-
+        <div>
+          <div>
               <h2>Hello World</h2>
-
               <h3>Images</h3>
 
-              <DividedCols
-              first={
-                <div>
+               <div>
                   <h4>Images from project</h4>
                   <p>50 euro image from src/images/</p>
                   <img src={url20e} style={{width: "100%"}} />
@@ -37,9 +30,8 @@ var HelloWorld = React.createClass({
                   <p>20 euro image from temp/generated-images/</p>
                   <img src={url50e} style={{width: "100%"}} />
                 </div>
-              }
-              second={
-                <div>
+
+                 <div>
                   <h4>Images from dependencies</h4>
                   <p>100 euro image from test_modules/module1/src/images/</p>
                   <img src={url100e} style={{width: "100%"}} />
@@ -47,8 +39,6 @@ var HelloWorld = React.createClass({
                   <p>200 euro image from test_modules/module1/temp/generated-images/</p>
                   <img src={url200e} style={{width: "100%"}} />
                 </div>
-              } />
-
           </div>
         </div>
 

--- a/test-projects/single-page-test-project/src/scss/styles.scss
+++ b/test-projects/single-page-test-project/src/scss/styles.scss
@@ -1,12 +1,4 @@
 
-:global {
-  @import '~lucify-commons/src/scss/styles-full.scss';
-}
-
-// import mixins, etc
-@import '~lucify-commons/src/scss/variables.scss';
-@import '~lucify-commons/src/scss/mixins.scss';
-
 
 .hello-world {
 
@@ -26,10 +18,6 @@
   h4 {
     font-size: 1.0rem;
     font-weight: normal;
-  }
-
-  p {
-    @include lucify-medium-paragraph()
   }
 
 }


### PR DESCRIPTION
Removes dependency on `lucify-commons`.

This includes:
- Using `lucify-embed-code` for creating embed codes
- Removing references to `lucify-commons` in test projects
